### PR TITLE
#59: changing grdalfa to grdalpha in General Parameters table

### DIFF
--- a/Manual.html
+++ b/Manual.html
@@ -160,7 +160,7 @@ n = 9; Was 10 before
                   <td>Bathymetry grid resolution. Only required when using XBeach style bathymetry need to be >0.0. Will be overwritten when using .md or .nc bathy input.</td>
                 </tr>
                 <tr>
-                  <td>grdalfa</td>
+                  <td>grdalpha</td>
                   <td>0.0</td>
                   <td>Bathymetry grid rotation. Only required when using XBeach style bathymetry or netcdf. Will be overwritten when using .md bathy input and can be included in the netcdf file explicitly.</td>
                 </tr>


### PR DESCRIPTION
Minor change to correct `grdalfa` to `grdalpha`. See corresponding change in #59 for `xb2xbg` script and unit tests.

Please review. Thanks @CyprienBosserelle.